### PR TITLE
missing --unsafe-perm for ffmpeg

### DIFF
--- a/homebridge-install
+++ b/homebridge-install
@@ -16,5 +16,5 @@ fi
 
 if [ ! -d /usr/local/lib/node_modules/homebridge-camera-ffmpeg ]; then
     sudo curl -Lf# https://github.com/homebridge/ffmpeg-for-homebridge/releases/latest/download/ffmpeg-debian-$(uname -m).tar.gz | sudo tar xzf - -C / --no-same-owner
-    sudo npm install -g homebridge-camera-ffmpeg@0.1.17
+    sudo npm install -g --unsafe-perm homebridge-camera-ffmpeg@0.1.17
 fi


### PR DESCRIPTION
  797.866179] cloud-init[1517]: Failed to download ffmpeg binary.
[  797.869448] cloud-init[1517]: If you are installing this plugin as a global module (-g) make sure you add the --unsafe-perm flag to the install command.
[  797.878919] cloud-init[1517]: The homebridge plugin has been installed, however you may need to install ffmpeg separately.