### PR TITLE
Adding "motion":true to get iOS rich notifications upon detection 

### DIFF
--- a/src/homebridge/HomebridgeConf.js
+++ b/src/homebridge/HomebridgeConf.js
@@ -78,6 +78,7 @@ module.exports = function(sensorController) {
                         "manufacturer": "Freebox",
                         "model": "RocketCam",
                         "serialNumber": '1337'+cam.id,
+                        "motion": true,
                         "videoConfig": {
                             "source": '-re -i rtsp://'+cam.ip+'/live',
                             "maxStreams": 1,


### PR DESCRIPTION
…or triggered

Could you please add the motion option to homebridge-camera-ffmpeg plugin to have rich notifications upon presence detector is triggered on the same Home room. 
Thanks for your amazing work!